### PR TITLE
Add LINKS_NEW_TAB option to open links in a new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Not much to it: Type to filter the links, press enter to visit the first one, or
 
 The page title is set using the `LINKS_TITLE` environment variable.
 
+#### Open links in new tab
+
+Set `LINKS_NEW_TAB=true` (or `1`) to open all links in a new browser tab instead of the current tab.
+
 #### Links
 
 Links have a name, URL, icon (optional), and sort index (optional). A link to this repo could be configured in various ways:

--- a/scripts/generate-config.sh
+++ b/scripts/generate-config.sh
@@ -7,7 +7,7 @@ mkdir -p "$(dirname "$out")"
 env_json=$(
   for var in $(compgen -e); do
     case "$var" in
-      LINK_*|LINKS_TITLE)
+      LINK_*|LINKS_*)
         jq -n --arg key "$var" --arg value "${!var}" '{key: $key, value: $value}'
         ;;
     esac

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   const env = (typeof window !== 'undefined' && window.env) || {};
   let links = getLinks(env);
   let title = env.LINKS_TITLE || 'Links';
+  let newTab = env.LINKS_NEW_TAB === 'true' || env.LINKS_NEW_TAB === '1';
   let search = "";
   let searchElement;
   let activeElement = null;
@@ -27,10 +28,14 @@
       }
     } else if (event.key == 'Enter'
                || event.target != searchElement.getInput() && event.key == ' ') {
+      const navigate = (url) => {
+        if (newTab) window.open(url, '_blank', 'noopener,noreferrer');
+        else window.location = url;
+      };
       if (activeElement && activeElement.classList.contains('link') && activeElement.href) {
-        window.location = activeElement.href;
+        navigate(activeElement.href);
       } else if (filteredLinks.length > 0) {
-        window.location = filteredLinks[0].url;
+        navigate(filteredLinks[0].url);
       }
     } else if (event.target != searchElement.getInput() && event.key.length == 1) {
       searchElement.reset(event.key)
@@ -68,6 +73,6 @@
             bind:this={searchElement}
             />
 
-    <Links links={filteredLinks} />
+    <Links links={filteredLinks} {newTab} />
   </div>
 </Layout>

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -3,6 +3,7 @@
   export let name;
   export let url;
   export let icon = null;
+  export let newTab = false;
 </script>
 
 
@@ -37,6 +38,8 @@
 <div class="link-container">
   <a href={url}
      class="link"
+     target={newTab ? '_blank' : '_self'}
+     rel={newTab ? 'noopener noreferrer' : undefined}
      >
     {#if icon}
     <div class="link-icon">

--- a/src/Links.svelte
+++ b/src/Links.svelte
@@ -2,6 +2,7 @@
   import Link from './Link.svelte';
 
   export let links;
+  export let newTab = false;
 </script>
 
 
@@ -15,6 +16,6 @@
 
 <div class="links">
   {#each links as link, i}
-    <Link {...link} />
+    <Link {...link} {newTab} />
   {/each}
 </div>


### PR DESCRIPTION
Closes #2

## Summary

- Adds a `LINKS_NEW_TAB` env var (accepts `true` or `1`) that makes all links open in a new browser tab
- Keyboard navigation (Enter/Space) also respects this setting via `window.open`
- `rel="noopener noreferrer"` is set automatically when new-tab mode is on

## Usage

```yaml
environment:
  LINKS_NEW_TAB: "true"
```

## Test plan

- [ ] Default behavior unchanged (links open in same tab) when `LINKS_NEW_TAB` is not set
- [ ] `LINKS_NEW_TAB=true` makes clicked links open in a new tab
- [ ] `LINKS_NEW_TAB=1` also works
- [ ] Keyboard Enter/Space navigation opens in a new tab when option is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)