### PR TITLE
Add LINKS_CSS env var for custom CSS injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The page title is set using the `LINKS_TITLE` environment variable.
 
 Set `LINKS_NEW_TAB=true` (or `1`) to open all links in a new browser tab instead of the current tab.
 
+#### Custom CSS
+
+Set `LINKS_CSS` to inject arbitrary CSS into the page. Useful for tweaking font size, colors, spacing, etc. without rebuilding the bundle. Example:
+
+```
+LINKS_CSS=":root { font-size: 18px; }"
+```
+
 #### Links
 
 Links have a name, URL, icon (optional), and sort index (optional). A link to this repo could be configured in various ways:

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,6 +9,12 @@
   let links = getLinks(env);
   let title = env.LINKS_TITLE || 'Links';
   let newTab = env.LINKS_NEW_TAB === 'true' || env.LINKS_NEW_TAB === '1';
+
+  if (env.LINKS_CSS) {
+    const style = document.createElement('style');
+    style.textContent = env.LINKS_CSS;
+    document.head.appendChild(style);
+  }
   let search = "";
   let searchElement;
   let activeElement = null;


### PR DESCRIPTION
Closes #3 

## Summary

- Adds a `LINKS_CSS` environment variable that injects arbitrary CSS into the page at startup
- Addresses #3 (font size request) while being general enough to handle any future styling needs (colors, spacing, etc.)
- No rebuild required — CSS is applied at runtime via `config.js`, consistent with the existing env-var pattern

## Usage

```
LINKS_CSS=":root { font-size: 18px; }"
```

## Test plan

- [ ] Set `LINKS_CSS=":root { font-size: 18px; }"` and confirm font size changes in the browser
- [ ] Leave `LINKS_CSS` unset and confirm no regressions
- [ ] Set an invalid/empty value and confirm the app still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)